### PR TITLE
Refactor `sign.ps1` script: rename parameters

### DIFF
--- a/sign.ps1
+++ b/sign.ps1
@@ -1,8 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
-    [string]$certicate="Open Source Developer, Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 Write-Host "NuGet Certificate: $certicate"  -ForegroundColor Magenta
@@ -26,9 +26,9 @@ dotnet pack -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageForm
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $certicate -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $certicate -o .\signed
 
-if ($dryrun)
+if (!$publish)
 {
-    Write-Host "Dryrun: Cryptography" -ForegroundColor Yellow;
+    write-host "Skip update: System" -ForegroundColor Yellow;
     exit;
 }
 


### PR DESCRIPTION
This pull request updates the `sign.ps1` script to improve clarity and functionality by renaming parameters and adjusting the logic for handling publish operations. The most important changes include renaming variables and parameters for better readability and modifying the conditional logic for the publish process.

### Parameter and variable renaming:
* Renamed the `$dryrun` parameter to `$publish` to better reflect its purpose, and updated its default value to `false`.
* Renamed the `$certicate` parameter to `$name` for clarity and consistency.

### Logic changes for publish operations:
* Updated the conditional check to use `!$publish` instead of `$dryrun`, and modified the corresponding message to "Skip update: System" for better context.