### PR TITLE
Remove `IsPackable` property from project file to streamline configur…

### DIFF
--- a/src/Application/Wangkanai.Tiler.Application.csproj
+++ b/src/Application/Wangkanai.Tiler.Application.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<PropertyGroup>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\Domain\Wangkanai.Tiler.Domain.csproj" PrivateAssets="all" />
 	</ItemGroup>


### PR DESCRIPTION
This pull request makes a small change to the `src/Application/Wangkanai.Tiler.Application.csproj` file by removing the `<IsPackable>` property, which was previously set to `false`. This likely indicates that the project is no longer concerned with being packaged as a NuGet package.