### PR TITLE
Refactor `sign.ps1`: simplify `Get-ChildItem` command

### DIFF
--- a/sign.ps1
+++ b/sign.ps1
@@ -17,8 +17,8 @@ dotnet --version
 dotnet clean    -c Release -tl
 dotnet restore
 dotnet build    -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
-    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $certicate $_.FullName
+Get-ChildItem   -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg


### PR DESCRIPTION
This pull request includes a small update to the `sign.ps1` script to adjust the signing process for `.dll` files.

* Replaced the `$certificate` variable with `$name` in the `signtool sign` command to reflect a change in the variable used for the certificate name.