### PR TITLE
Change `GetCommand` class visibility from `internal` to `public`.

### DIFF
--- a/src/Console/Commands/GetCommand.cs
+++ b/src/Console/Commands/GetCommand.cs
@@ -2,7 +2,7 @@
 
 namespace Wangkanai.Tiler.Console.Commands;
 
-internal class GetCommand
+public class GetCommand
 {
-	
+
 }


### PR DESCRIPTION
This pull request makes a small but important change to the `GetCommand` class in the `src/Console/Commands/GetCommand.cs` file. The class's access modifier has been changed from `internal` to `public`, making it accessible outside its assembly.